### PR TITLE
Fix flag error

### DIFF
--- a/jax/install_jax_tigergpu.sh
+++ b/jax/install_jax_tigergpu.sh
@@ -10,7 +10,7 @@ module load cudatoolkit/10.2 cudnn/cuda-10.2/7.6.5 rh/devtoolset/8
 python build/build.py --enable_cuda  \
                       --cudnn_path /usr/local/cudnn/cuda-10.2/7.6.5 \
                       --cuda_compute_capabilities 6.0 \
-                      --enable_march_native \
+                      --target_cpu_features native \
                       --enable_mkl_dnn
 pip install dist/*.whl
 pip install -e .


### PR DESCRIPTION
While attempting to install JAX on tigerpu, I found that executing the script causes the following error:

`build.py: error: unrecognized arguments: --enable_march_native`

The comments around the flags in the source code at https://github.com/google/jax/blob/c7ebc3ed7431c774cccd5a02b0d2fd25d6422b9a/build/build.py#L361 indicate that `--target_cpu_features native` enables march=native.

I tested the fix, and the script now successfully builds JAX with the following features:

```
Python version: 3.8
MKL-DNN enabled: yes
Target CPU features: native
CUDA enabled: yes
CUDNN library path: /usr/local/cudnn/cuda-10.2/7.6.5
CUDA compute capabilities: 6.0
TPU enabled: no
ROCm enabled: no
```